### PR TITLE
Add markers for first five stations on initial load.

### DIFF
--- a/static/css/player.css
+++ b/static/css/player.css
@@ -46,7 +46,7 @@ h1, h3 {
     bottom: 0;
     width: 100%;
     border-top: solid 3px #000;
-    height: 80px;
+    height: 55px;
 }
 
 .changeStationText {
@@ -57,7 +57,7 @@ h1, h3 {
 
 .verticalCenter {
     min-height: 100%;
-    min-height: calc(100vh - 136px);
+    min-height: calc(100vh - 50px);
     display: flex;
     align-items: center;
     width: 100%;

--- a/static/js/MapManager.js
+++ b/static/js/MapManager.js
@@ -41,7 +41,7 @@ var NowRadio = (function (nr) {
         var iconStyle = {
             path: google.maps.SymbolPath.CIRCLE,
             scale: 8,
-            fillOpacity: 0.4,
+            fillOpacity: 0.8,
             strokeWeight: 1.5,
             strokeColor: '#000',
             fillColor: nr.Utils.genreNumToColor(genreNum),

--- a/static/js/MapManager.js
+++ b/static/js/MapManager.js
@@ -5,7 +5,9 @@
  */
 var NowRadio = (function (nr) {
     'use strict';
-    nr.MapManager = {};
+    nr.MapManager = {
+        visibleMarkers: []
+    };
     var style = [{"featureType":"all","elementType":"labels.text.fill","stylers":[{"saturation":36},{"color":"#000000"},{"lightness":40}]},{"featureType":"all","elementType":"labels.text.stroke","stylers":[{"visibility":"on"},{"color":"#000000"},{"lightness":16}]},{"featureType":"all","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"administrative","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"administrative","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":17},{"weight":1.2}]},{"featureType":"landscape","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":20}]},{"featureType":"poi","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":21}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#000000"},{"lightness":17}]},{"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#000000"},{"lightness":29},{"weight":0.2}]},{"featureType":"road.arterial","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":18}]},{"featureType":"road.local","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":16}]},{"featureType":"transit","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":19}]},{"featureType":"water","elementType":"geometry","stylers":[{"color":"#000000"},{"lightness":17}]}]
     window.initMap = nr.MapManager.initMap = function () {
         var map = new google.maps.Map(document.querySelector('.verticalCenter'), {
@@ -20,6 +22,39 @@ var NowRadio = (function (nr) {
         });
 
         nr.MapManager.map = map;
+    }
+
+    nr.MapManager.setMapToNull = function (marker) {
+        marker.setMap(null);
+    }
+
+    nr.MapManager.showInitialMarkers = function (stations) {
+        stations.forEach(function (stationList, genreNum) {
+            stationList.slice(0, 5).forEach(function (station) {
+                nr.MapManager.addMarker(station, genreNum);
+            })
+        });
+
+    }
+
+    nr.MapManager.addMarker = function (station, genreNum) {
+        var iconStyle = {
+            path: google.maps.SymbolPath.CIRCLE,
+            scale: 8,
+            fillOpacity: 0.4,
+            strokeWeight: 1.5,
+            strokeColor: '#000',
+            fillColor: nr.Utils.genreNumToColor(genreNum),
+        };
+        var pos = {
+            lat: station.latitude,
+            lng: station.longitude
+        };
+        nr.MapManager.visibleMarkers.push(new google.maps.Marker({
+            position: pos,
+            icon: iconStyle,
+            map: nr.MapManager.map
+        }))
     }
     return nr;
 }(NowRadio || {}));

--- a/static/js/StationsManager.js
+++ b/static/js/StationsManager.js
@@ -102,9 +102,14 @@ var NowRadio = (function(nr) {
                         approved_stations.push(station_dict.ip_addr);
                     }
                 });
+
                 genreLists.push(approved_stations);
                 genreMarkers.push(0);
             });
+
+            // Pass station data to MapManager, set inital markers.
+            nr.MapManager.showInitialMarkers(data.stations);
+
             if (nr.UrlManager.getHash().length == 0) {
                 // selecting genreNum based on the current selection of favorites
                 // if there are no favorites, a random genre is picked

--- a/templates/player.html
+++ b/templates/player.html
@@ -96,6 +96,7 @@
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="{{ url_for('static', filename='js/Setup.js') }}"></script>
     <script src="{{ url_for('static', filename='js/FaveManager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/MapManager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/StationsManager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/SongNameManager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/Utils.js') }}"></script>
@@ -108,6 +109,5 @@
     <script src="{{ url_for('static', filename='js/MainController.js') }}"></script>
     <script src="{{ url_for('static', filename='js/FaviconManager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/velocity.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/MapManager.js') }}"></script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCXVKwm6zy_GZuYVybbRlyAcZoVZw8fipY&callback=initMap"></script>
 {% endblock %}


### PR DESCRIPTION
on initial load:
- call function from MapManager 
- for each station list, slice the first 5 stations
- pass each station, it's index and its lat/long to addMarker
- move MapManager file load above StationsManager

also:
- make map reach bottom of page (visible through transparent control bar)
- make control bar shorter
